### PR TITLE
Say hello

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,22 +19,21 @@
     }
     
     .container {
-      max-width: 1400px;
+      max-width: 900px;
       margin: 20px auto;
       padding: 20px;
       background: white;
       border-radius: 12px;
       box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-      display: grid;
-      grid-template-columns: 280px 1fr 300px;
-      gap: 24px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       min-height: calc(100vh - 80px);
     }
     
     /* Templates Column */
     .templates-section {
-      border-right: 1px solid #e9ecef;
-      padding-right: 20px;
+      display: none;
     }
     
     .templates-section h3 {
@@ -125,6 +124,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      width: 100%;
       padding: 20px;
     }
     
@@ -171,8 +171,7 @@
     
     /* Editor Column */
     .editor-section {
-      border-left: 1px solid #e9ecef;
-      padding-left: 20px;
+      display: none;
     }
     
     .editor-section h3 {


### PR DESCRIPTION
Refactor UI layout to a single centered section.

The user requested a single-section UI layout, which was achieved by converting the `.container` from a 3-column grid to a centered flex container and hiding the `templates` and `editor` panels.

---
<a href="https://cursor.com/background-agent?bcId=bc-11ab744e-cb03-465d-bb95-b36fffb0a2d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11ab744e-cb03-465d-bb95-b36fffb0a2d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

